### PR TITLE
Refactor frontend components and config

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -122,7 +122,7 @@ Then, when you run the frontend, it will use that URL as the base URL for the AP
 The frontend code is structured as follows:
 
 * `frontend/src` - The main frontend code.
-* `frontend/src/assets` - Static assets.
+* `frontend/public/assets` - Static assets.
 * `frontend/src/client` - The generated OpenAPI client.
 * `frontend/src/components` -  The different components of the frontend.
 * `frontend/src/hooks` - Custom hooks.

--- a/frontend/src/components/Admin/AnalyticsDashboard.tsx
+++ b/frontend/src/components/Admin/AnalyticsDashboard.tsx
@@ -41,6 +41,7 @@ import {
   Tooltip
 } from '@chakra-ui/react'
 import { Icon } from '@chakra-ui/react'
+import RevenueOverview from './RevenueOverview'
 import { 
   FiTrendingUp, 
   FiTrendingDown, 
@@ -405,107 +406,12 @@ const AnalyticsDashboard: React.FC = () => {
         )}
 
         {/* Revenue Overview */}
-        <Box>
-          <Heading size="md" mb={4}>Revenue Overview</Heading>
-          <Grid templateColumns="repeat(auto-fit, minmax(250px, 1fr))" gap={4}>
-            <Card>
-              <CardBody>
-                <Stat>
-                  <StatLabel>
-                    <HStack>
-                      <Icon as={FiDollarSign} boxSize={4} />
-                      <Text>Today's Revenue</Text>
-                    </HStack>
-                  </StatLabel>
-                  <StatNumber>{formatCurrency(financialData?.revenue.today || 0)}</StatNumber>
-                  <StatHelpText>
-                    Real-time: {formatCurrency(realtimeData?.current_revenue_today || 0)}
-                  </StatHelpText>
-                </Stat>
-              </CardBody>
-            </Card>
-
-            <Card>
-              <CardBody>
-                <Stat>
-                  <StatLabel>
-                    <HStack>
-                      <Icon as={FiDollarSign} boxSize={4} />
-                      <Text>Monthly Revenue</Text>
-                    </HStack>
-                  </StatLabel>
-                  <StatNumber>{formatCurrency(financialData?.revenue.month || 0)}</StatNumber>
-                  <StatHelpText>
-                    <StatArrow 
-                      type={financialData?.revenue.growth_rate >= 0 ? 'increase' : 'decrease'} 
-                    />
-                    {formatPercentage(Math.abs(financialData?.revenue.growth_rate || 0))} growth
-                  </StatHelpText>
-                </Stat>
-              </CardBody>
-            </Card>
-
-            <Card>
-              <CardBody>
-                <Stat>
-                  <StatLabel>
-                    <HStack>
-                      <Icon as={FiTrendingUp} boxSize={4} />
-                      <Text>MRR</Text>
-                    </HStack>
-                  </StatLabel>
-                  <StatNumber>{formatCurrency(financialData?.revenue.mrr || 0)}</StatNumber>
-                  <StatHelpText>Monthly Recurring Revenue</StatHelpText>
-                </Stat>
-              </CardBody>
-            </Card>
-
-            <Card>
-              <CardBody>
-                <Stat>
-                  <StatLabel>
-                    <HStack>
-                      <Icon as={FiTrendingUp} boxSize={4} />
-                      <Text>ARR</Text>
-                    </HStack>
-                  </StatLabel>
-                  <StatNumber>{formatCurrency(financialData?.revenue.arr || 0)}</StatNumber>
-                  <StatHelpText>Annual Recurring Revenue</StatHelpText>
-                </Stat>
-              </CardBody>
-            </Card>
-
-            <Card>
-              <CardBody>
-                <Stat>
-                  <StatLabel>
-                    <HStack>
-                      <Icon as={FiShoppingCart} boxSize={4} />
-                      <Text>Average Order Value</Text>
-                    </HStack>
-                  </StatLabel>
-                  <StatNumber>{formatCurrency(financialData?.orders.average_order_value || 0)}</StatNumber>
-                  <StatHelpText>Per completed order</StatHelpText>
-                </Stat>
-              </CardBody>
-            </Card>
-
-            <Card>
-              <CardBody>
-                <Stat>
-                  <StatLabel>
-                    <HStack>
-                      <Icon as={FiUsers} boxSize={4} />
-                      <Text>Revenue Per Visitor</Text>
-                    </HStack>
-                  </StatLabel>
-                  <StatNumber>{formatCurrency(financialData?.revenue.revenue_per_visitor || 0)}</StatNumber>
-                  <StatHelpText>RPV (30 days)</StatHelpText>
-                </Stat>
-              </CardBody>
-            </Card>
-          </Grid>
-        </Box>
+        <RevenueOverview
+          financialData={financialData}
+          realtimeData={realtimeData}
+          formatCurrency={formatCurrency}
+          formatPercentage={formatPercentage}
+        />
 
         {/* KPI Summary Cards */}
         <Box>

--- a/frontend/src/components/Admin/RevenueOverview.tsx
+++ b/frontend/src/components/Admin/RevenueOverview.tsx
@@ -1,0 +1,115 @@
+import { Box, Grid, Card, CardBody, Stat, StatLabel, StatNumber, StatHelpText, HStack, Text, Icon, StatArrow, Heading } from "@chakra-ui/react";
+import { FiDollarSign, FiTrendingUp, FiShoppingCart, FiUsers } from "react-icons/fi";
+import React from "react";
+import type { FinancialSummary, RealtimeMetrics } from "../../services/AnalyticsService";
+
+interface RevenueOverviewProps {
+  financialData: FinancialSummary | null;
+  realtimeData: RealtimeMetrics | null;
+  formatCurrency: (amount: number) => string;
+  formatPercentage: (value: number) => string;
+}
+
+const RevenueOverview: React.FC<RevenueOverviewProps> = ({ financialData, realtimeData, formatCurrency, formatPercentage }) => (
+  <Box>
+    <Heading size="md" mb={4}>Revenue Overview</Heading>
+    <Grid templateColumns="repeat(auto-fit, minmax(250px, 1fr))" gap={4}>
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>
+              <HStack>
+                <Icon as={FiDollarSign} boxSize={4} />
+                <Text>Today's Revenue</Text>
+              </HStack>
+            </StatLabel>
+            <StatNumber>{formatCurrency(financialData?.revenue.today || 0)}</StatNumber>
+            <StatHelpText>
+              Real-time: {formatCurrency(realtimeData?.current_revenue_today || 0)}
+            </StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>
+              <HStack>
+                <Icon as={FiDollarSign} boxSize={4} />
+                <Text>Monthly Revenue</Text>
+              </HStack>
+            </StatLabel>
+            <StatNumber>{formatCurrency(financialData?.revenue.month || 0)}</StatNumber>
+            <StatHelpText>
+              <StatArrow type={financialData?.revenue.growth_rate >= 0 ? 'increase' : 'decrease'} />
+              {formatPercentage(Math.abs(financialData?.revenue.growth_rate || 0))} growth
+            </StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>
+              <HStack>
+                <Icon as={FiTrendingUp} boxSize={4} />
+                <Text>MRR</Text>
+              </HStack>
+            </StatLabel>
+            <StatNumber>{formatCurrency(financialData?.revenue.mrr || 0)}</StatNumber>
+            <StatHelpText>Monthly Recurring Revenue</StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>
+              <HStack>
+                <Icon as={FiTrendingUp} boxSize={4} />
+                <Text>ARR</Text>
+              </HStack>
+            </StatLabel>
+            <StatNumber>{formatCurrency(financialData?.revenue.arr || 0)}</StatNumber>
+            <StatHelpText>Annual Recurring Revenue</StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>
+              <HStack>
+                <Icon as={FiShoppingCart} boxSize={4} />
+                <Text>Average Order Value</Text>
+              </HStack>
+            </StatLabel>
+            <StatNumber>{formatCurrency(financialData?.orders.average_order_value || 0)}</StatNumber>
+            <StatHelpText>Per completed order</StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <Stat>
+            <StatLabel>
+              <HStack>
+                <Icon as={FiUsers} boxSize={4} />
+                <Text>Revenue Per Visitor</Text>
+              </HStack>
+            </StatLabel>
+            <StatNumber>{formatCurrency(financialData?.revenue.revenue_per_visitor || 0)}</StatNumber>
+            <StatHelpText>RPV (30 days)</StatHelpText>
+          </Stat>
+        </CardBody>
+      </Card>
+    </Grid>
+  </Box>
+);
+
+export default RevenueOverview;

--- a/frontend/src/components/Items/AddItem.tsx
+++ b/frontend/src/components/Items/AddItem.tsx
@@ -12,12 +12,9 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { type SubmitHandler, useForm } from "react-hook-form"
 
-import { type ApiError, type ItemCreate, ItemsService } from "../../client"
-import useCustomToast from "../../hooks/useCustomToast"
-import { handleError } from "../../utils"
+import { type ItemCreate, ItemsService } from "../../client"
+import useItemForm from "../../hooks/useItemForm"
 
 interface AddItemProps {
   isOpen: boolean
@@ -25,41 +22,18 @@ interface AddItemProps {
 }
 
 const AddItem = ({ isOpen, onClose }: AddItemProps) => {
-  const queryClient = useQueryClient()
-  const showToast = useCustomToast()
   const {
     register,
     handleSubmit,
-    reset,
     formState: { errors, isSubmitting },
-  } = useForm<ItemCreate>({
-    mode: "onBlur",
-    criteriaMode: "all",
-    defaultValues: {
-      title: "",
-      description: "",
-    },
-  })
-
-  const mutation = useMutation({
+    onSubmit,
+  } = useItemForm<ItemCreate>({
+    defaultValues: { title: "", description: "" },
     mutationFn: (data: ItemCreate) =>
       ItemsService.createItem({ requestBody: data }),
-    onSuccess: () => {
-      showToast("Success!", "Item created successfully.", "success")
-      reset()
-      onClose()
-    },
-    onError: (err: ApiError) => {
-      handleError(err, showToast)
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["items"] })
-    },
+    successMessage: "Item created successfully.",
+    onSuccess: onClose,
   })
-
-  const onSubmit: SubmitHandler<ItemCreate> = (data) => {
-    mutation.mutate(data)
-  }
 
   return (
     <>

--- a/frontend/src/components/Items/EditItem.tsx
+++ b/frontend/src/components/Items/EditItem.tsx
@@ -12,17 +12,13 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { type SubmitHandler, useForm } from "react-hook-form"
 
 import {
-  type ApiError,
   type ItemPublic,
   type ItemUpdate,
   ItemsService,
 } from "../../client"
-import useCustomToast from "../../hooks/useCustomToast"
-import { handleError } from "../../utils"
+import useItemForm from "../../hooks/useItemForm"
 
 interface EditItemProps {
   item: ItemPublic
@@ -31,40 +27,20 @@ interface EditItemProps {
 }
 
 const EditItem = ({ item, isOpen, onClose }: EditItemProps) => {
-  const queryClient = useQueryClient()
-  const showToast = useCustomToast()
   const {
     register,
     handleSubmit,
-    reset,
     formState: { isSubmitting, errors, isDirty },
-  } = useForm<ItemUpdate>({
-    mode: "onBlur",
-    criteriaMode: "all",
+    onSubmit,
+  } = useItemForm<ItemUpdate>({
     defaultValues: item,
-  })
-
-  const mutation = useMutation({
     mutationFn: (data: ItemUpdate) =>
       ItemsService.updateItem({ id: item.id, requestBody: data }),
-    onSuccess: () => {
-      showToast("Success!", "Item updated successfully.", "success")
-      onClose()
-    },
-    onError: (err: ApiError) => {
-      handleError(err, showToast)
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["items"] })
-    },
+    successMessage: "Item updated successfully.",
+    onSuccess: onClose,
   })
 
-  const onSubmit: SubmitHandler<ItemUpdate> = async (data) => {
-    mutation.mutate(data)
-  }
-
   const onCancel = () => {
-    reset()
     onClose()
   }
 

--- a/frontend/src/hooks/useItemForm.ts
+++ b/frontend/src/hooks/useItemForm.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import type { ApiError } from "../client";
+import useCustomToast from "./useCustomToast";
+import { handleError } from "../utils";
+
+interface UseItemFormOptions<T> {
+  defaultValues: T;
+  mutationFn: (data: T) => Promise<unknown>;
+  successMessage: string;
+  onSuccess?: () => void;
+}
+
+function useItemForm<T>(options: UseItemFormOptions<T>) {
+  const queryClient = useQueryClient();
+  const showToast = useCustomToast();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState,
+  } = useForm<T>({
+    mode: "onBlur",
+    criteriaMode: "all",
+    defaultValues: options.defaultValues,
+  });
+
+  const mutation = useMutation({
+    mutationFn: options.mutationFn,
+    onSuccess: () => {
+      showToast("Success!", options.successMessage, "success");
+      options.onSuccess?.();
+      reset();
+    },
+    onError: (err: ApiError) => handleError(err, showToast),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["items"] });
+    },
+  });
+
+  const onSubmit: SubmitHandler<T> = (data) => mutation.mutate(data);
+
+  return { register, handleSubmit, formState, onSubmit, isSubmitting: formState.isSubmitting };
+}
+
+export default useItemForm;

--- a/frontend/src/services/NotificationService.ts
+++ b/frontend/src/services/NotificationService.ts
@@ -19,13 +19,18 @@ class NotificationService {
       this.disconnect();
     }
 
-    const wsUrl = `ws://localhost:8000/api/v1/ws/notifications/${userId}`;
-    console.log('Connecting to WebSocket:', wsUrl);
+    const baseUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8000';
+    const wsUrl = `${baseUrl}/api/v1/ws/notifications/${userId}`;
+    if (import.meta.env.DEV) {
+      console.debug('Connecting to WebSocket:', wsUrl);
+    }
     
     this.ws = new WebSocket(wsUrl);
     
     this.ws.onopen = () => {
-      console.log('WebSocket connected');
+      if (import.meta.env.DEV) {
+        console.debug('WebSocket connected');
+      }
       this.reconnectAttempts = 0;
       
       // Update role if not default
@@ -39,7 +44,9 @@ class NotificationService {
     this.ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
-        console.log('WebSocket message received:', data);
+        if (import.meta.env.DEV) {
+          console.debug('WebSocket message received:', data);
+        }
         
         // Emit specific event type
         this.emit(data.type || 'message', data);
@@ -56,14 +63,18 @@ class NotificationService {
     };
     
     this.ws.onclose = (event) => {
-      console.log('WebSocket disconnected:', event.code, event.reason);
+      if (import.meta.env.DEV) {
+        console.debug('WebSocket disconnected:', event.code, event.reason);
+      }
       this.emit('disconnected', { code: event.code, reason: event.reason });
       
       // Attempt to reconnect
       if (this.reconnectAttempts < this.maxReconnectAttempts) {
         setTimeout(() => {
           this.reconnectAttempts++;
-          console.log(`Reconnecting attempt ${this.reconnectAttempts}...`);
+          if (import.meta.env.DEV) {
+            console.debug(`Reconnecting attempt ${this.reconnectAttempts}...`);
+          }
           this.connect(userId, role);
         }, this.reconnectInterval * Math.pow(2, this.reconnectAttempts));
       }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom'
 
 // Mock environment variables
 process.env.VITE_API_URL = 'http://localhost:8000'
+process.env.VITE_WS_URL = 'ws://localhost:8000'
 
 // Mock localStorage
 const localStorageMock = (() => {


### PR DESCRIPTION
## Summary
- split revenue cards into new `RevenueOverview` component
- move WebSocket URL to `VITE_WS_URL` env var and log only in dev
- introduce reusable `useItemForm` hook and refactor item forms
- fix assets path documentation
- update test setup for new env variable

## Testing
- `make test-frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a236b1c48832e8c065f4380f3e103