### PR TITLE
Fix order stats and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python Version](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 [![Node Version](https://img.shields.io/badge/node-20+-green.svg)](https://nodejs.org/)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://www.docker.com/)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.104+-green.svg)](https://fastapi.tiangolo.com/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.114+-green.svg)](https://fastapi.tiangolo.com/)
 
 **Brain2Gain** is a modern e-commerce platform specialized in sports supplements, built with a **modular monolithic architecture** that combines operational simplicity with enterprise scalability to deliver exceptional shopping experiences and integrated management tools.
 
@@ -71,7 +71,7 @@
 ### Current Technology Stack
 ```yaml
 Backend (Phase 1 MVP Complete):
-  Framework: FastAPI 0.104+
+  Framework: FastAPI 0.114+
   Database: PostgreSQL 17 + SQLModel
   Cache: Redis 7.2+ with strategic caching
   Package Manager: uv (ultra-fast dependency resolution)

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -459,27 +459,27 @@ class OrderService:
             count_stmt = select(func.count(Order.order_id)).where(
                 Order.status == order_status
             )
-            count = self.session.exec(count_stmt).first()
+            count = self.session.exec(count_stmt).scalar_one()
             status_counts[order_status.value] = count
 
         # Revenue calculations
         revenue_stmt = select(func.sum(Order.total_amount)).where(
             Order.status.in_([OrderStatus.DELIVERED, OrderStatus.SHIPPED])
         )
-        total_revenue = self.session.exec(revenue_stmt).first() or Decimal(0)
+        total_revenue = self.session.exec(revenue_stmt).scalar() or Decimal(0)
 
         # Average order value
         avg_stmt = select(func.avg(Order.total_amount)).where(
             Order.status.in_([OrderStatus.DELIVERED, OrderStatus.SHIPPED])
         )
-        avg_order_value = self.session.exec(avg_stmt).first() or Decimal(0)
+        avg_order_value = self.session.exec(avg_stmt).scalar() or Decimal(0)
 
         # Orders today
         today = datetime.now().date()
         today_stmt = select(func.count(Order.order_id)).where(
             func.date(Order.created_at) == today
         )
-        orders_today = self.session.exec(today_stmt).first()
+        orders_today = self.session.exec(today_stmt).scalar_one()
 
         return {
             "total_orders": sum(status_counts.values()),


### PR DESCRIPTION
## Summary
- fix `get_order_statistics` to use `.scalar()` methods
- adjust tests for `get_order_statistics` and add varied counts scenario
- document required FastAPI version in README

## Testing
- `pytest backend/app/tests/unit/services/test_order_service.py::TestOrderStatistics::test_get_order_statistics -q`
- `pytest backend/app/tests/unit/services/test_order_service.py::TestOrderStatistics::test_get_order_statistics_varied_counts -q`
- `pytest -q` *(fails: 56 failed, 172 passed, 127 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c34455408832e948eabb07118fcb9